### PR TITLE
Ore blocks dropped legacy essence instead of current

### DIFF
--- a/src/main/resources/data/mysticalcrops/loot_tables/blocks/deepslate_essence_ore.json
+++ b/src/main/resources/data/mysticalcrops/loot_tables/blocks/deepslate_essence_ore.json
@@ -50,7 +50,7 @@
                   "function": "minecraft:explosion_decay"
                 }
               ],
-              "name": "mysticalcrops:basic_essence"
+              "name": "mysticalcrops:common_essence"
             }
           ]
         }

--- a/src/main/resources/data/mysticalcrops/loot_tables/blocks/end_essence_ore.json
+++ b/src/main/resources/data/mysticalcrops/loot_tables/blocks/end_essence_ore.json
@@ -50,7 +50,7 @@
                   "function": "minecraft:explosion_decay"
                 }
               ],
-              "name": "mysticalcrops:basic_essence"
+              "name": "mysticalcrops:common_essence"
             }
           ]
         }

--- a/src/main/resources/data/mysticalcrops/loot_tables/blocks/essence_ore.json
+++ b/src/main/resources/data/mysticalcrops/loot_tables/blocks/essence_ore.json
@@ -50,7 +50,7 @@
                   "function": "minecraft:explosion_decay"
                 }
               ],
-              "name": "mysticalcrops:basic_essence"
+              "name": "mysticalcrops:common_essence"
             }
           ]
         }

--- a/src/main/resources/data/mysticalcrops/loot_tables/blocks/nether_essence_ore.json
+++ b/src/main/resources/data/mysticalcrops/loot_tables/blocks/nether_essence_ore.json
@@ -50,7 +50,7 @@
                   "function": "minecraft:explosion_decay"
                 }
               ],
-              "name": "mysticalcrops:basic_essence"
+              "name": "mysticalcrops:common_essence"
             }
           ]
         }


### PR DESCRIPTION
**Description**
When mining essence ore blocks, the old legacy entities are dropped which are missing correct textures:

[drops.webm](https://github.com/Marwinkas/Mystical-Nature/assets/4460715/21a45264-3dd3-4e0d-a610-e758da3c60bd)

This pull request changes them to the update names


