### PR TITLE
Make botanical table only allow knives and fruits in its slots

### DIFF
--- a/src/main/java/net/marwinka/mysticalcrops/block/entity/BotanicalEntity.java
+++ b/src/main/java/net/marwinka/mysticalcrops/block/entity/BotanicalEntity.java
@@ -1,9 +1,12 @@
 package net.marwinka.mysticalcrops.block.entity;
 
+import net.marwinka.mysticalcrops.MysticalCrops;
 import net.marwinka.mysticalcrops.recipe.BotanicalRecipe;
 import net.marwinka.mysticalcrops.registry.ModBlockEntities;
 import net.marwinka.mysticalcrops.registry.ModRecipes;
 import net.marwinka.mysticalcrops.screenhandler.BotanicalHandler;
+import net.marwinka.mysticalcrops.util.tags;
+
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
@@ -12,6 +15,9 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
@@ -20,15 +26,33 @@ public class BotanicalEntity extends AbstractTableEntity {
     public BotanicalEntity(BlockPos pos, BlockState state) {
         super(ModBlockEntities.BOTANICAL_TABLE, pos, state,200);
     }
+
     @Nullable
     @Override
     public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
         return new BotanicalHandler(syncId, inv, this, this.propertyDelegate);
     }
+
+    @Override
+    public boolean canInsert(int slot, ItemStack stack, @Nullable Direction side) {
+      Identifier id = Registry.ITEM.getId(stack.getItem());
+
+      // NOTE: All fruits are dynamically created and therefore no predefined set exists
+      // Hence matching by id is the easiest option until the registration is refactored
+      boolean isFruit = id.getNamespace() == MysticalCrops.MOD_ID && id.getPath().endsWith("_fruit");
+      boolean isKnive = stack.isIn(tags.KNIVES);
+
+      if (!isFruit && !isKnive) {
+        return false;
+      }
+      return super.canInsert(slot, stack, side);
+    }
+
     @Override
     public boolean canExtract(int slot, ItemStack stack, Direction side) {
         return slot == 2;
     }
+
     public void tick() {
         if (!this.world.isClient) {
             SimpleInventory inventory = new SimpleInventory(this.size());

--- a/src/main/java/net/marwinka/mysticalcrops/screenhandler/BotanicalHandler.java
+++ b/src/main/java/net/marwinka/mysticalcrops/screenhandler/BotanicalHandler.java
@@ -3,6 +3,7 @@ package net.marwinka.mysticalcrops.screenhandler;
 import net.marwinka.mysticalcrops.block.entity.BotanicalEntity;
 import net.marwinka.mysticalcrops.registry.ModScreenHandler;
 import net.marwinka.mysticalcrops.util.inventory.KnifeSlot;
+import net.marwinka.mysticalcrops.util.inventory.FruitSlot;
 import net.marwinka.mysticalcrops.util.inventory.OutputSlot;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -33,7 +34,7 @@ public class BotanicalHandler extends ScreenHandler {
         this.blockEntity = (BotanicalEntity) entity;
 
         this.addSlot(new KnifeSlot(inventory, 0, 45, 60));
-        this.addSlot(new Slot(inventory, 1, 45, 24));
+        this.addSlot(new FruitSlot(inventory, 1, 45, 24));
         this.addSlot(new OutputSlot(inventory, 2, 116, 42));
         this.addSlot(new OutputSlot(inventory, 3, -10, -10));
         this.addSlot(new OutputSlot(inventory, 4, -10, -10));

--- a/src/main/java/net/marwinka/mysticalcrops/util/inventory/FruitSlot.java
+++ b/src/main/java/net/marwinka/mysticalcrops/util/inventory/FruitSlot.java
@@ -1,0 +1,28 @@
+package net.marwinka.mysticalcrops.util.inventory;
+
+import net.marwinka.mysticalcrops.MysticalCrops;
+
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+
+public class FruitSlot extends Slot {
+    public FruitSlot(Inventory inventory, int index, int x, int y) {
+        super(inventory, index, x, y);
+    }
+
+    @Override
+    public boolean canInsert(ItemStack stack) {
+      Identifier id = Registry.ITEM.getId(stack.getItem());
+
+      // NOTE: All fruits are dynamically created and therefore no predefined set exists
+      // Hence matching by id is the easiest option until the registration is refactored
+      if (id.getNamespace() == MysticalCrops.MOD_ID && id.getPath().endsWith("_fruit")) {
+        return true;
+      }
+      return false;
+    }
+}


### PR DESCRIPTION

Currently the table only determines if a type is stackable and put it in slot 1. This means any stackable item can be inserted in the fruit slot.

![image](https://github.com/Marwinkas/Mystical-Nature/assets/4460715/c0378ef7-37b7-4aaf-bf46-6a4bb479da53)

This is not nice from a usage standpoint since the table is only usable for fruits. This check adds to make sure only `knives` and `fruits` can be inserted
